### PR TITLE
debugged error message for mailto attribute

### DIFF
--- a/index.html
+++ b/index.html
@@ -142,7 +142,7 @@
 											<a href="#"><i class="fas fa-phone"></i> (956) 241-1709</a>
 										</li>
 										<li>
-											<a href="mailto: krystal.e.garcia@gmail.com"
+											<a href="mailto:krystal.e.garcia@gmail.com"
 												><i class="far fa-envelope"></i>
 												krystal.e.garcia@gmail.com</a>
 										</li>


### PR DESCRIPTION
When checking my deployed portfolio in the W3 validator, there was an error message for an incorrect spacing that was listed in the "mailto" attribute. 

closes #23 